### PR TITLE
Force TLS 1.1 or higher in constructor

### DIFF
--- a/Freshdesk/FreshdeskService.cs
+++ b/Freshdesk/FreshdeskService.cs
@@ -48,6 +48,12 @@ namespace Freshdesk
         {
             this.ApiKey = apiKey;
             this.ApiUri = apiUri;
+            // Force TLS 1.1 or higher. Anything lower is deprecated in the Freshdesk API as of 2016-09-30
+            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls11;
+            foreach (SecurityProtocolType p in SecurityProtocolType.GetValues(typeof(SecurityProtocolType)))
+            {
+                if (p > SecurityProtocolType.Tls11) ServicePointManager.SecurityProtocol |= p;
+            }
         }
         #endregion
 


### PR DESCRIPTION
As of 2016-09-30, Freshdesk is deprecating support for TLS 1.0 and below in v1 of their API: https://support.freshdesk.com/support/solutions/articles/221629-testing-for-api-compatibility
This forces TLS 1.0 or whatever higher is available.
